### PR TITLE
Support Stage and Scene as FXML file root

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ task run (dependsOn: assemble, overwrite: true) {
     doLast {
         String jarPath = relativePath(new File(libsDir, shadowJar.baseName + "-" + version + "-all.jar"))
         javaexec
-                { main = '-jar'; args jarPath }
+                { main = '-jar'; args jarPath; enableAssertions = true }
     }
 }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/DeleteObjectJob.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/DeleteObjectJob.java
@@ -39,6 +39,8 @@ import com.oracle.javafx.scenebuilder.kit.fxom.FXOMIntrinsic;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import java.util.ArrayList;
 import java.util.List;
+
+import javafx.scene.Scene;
 import javafx.scene.chart.Axis;
 
 /**
@@ -65,6 +67,10 @@ public class DeleteObjectJob extends InlineDocumentJob {
             result = true;
         } else if (targetFxomObject.getSceneGraphObject() instanceof Axis) {
             // Axis cannot be deleted from their parent Chart
+            result = false;
+        } else if (targetFxomObject.getParentObject() != null &&
+                targetFxomObject.getParentObject().getSceneGraphObject() instanceof Scene) {
+            // Scene root cannot be deleted
             result = false;
         } else {
             result = (targetFxomObject.getParentProperty() != null);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/UnwrapJob.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/UnwrapJob.java
@@ -127,6 +127,7 @@ public class UnwrapJob extends BatchSelectionJob {
                 assert parentContainerMask.isAcceptingAccessory(Accessory.CONTENT)
                         || parentContainerMask.isAcceptingAccessory(Accessory.GRAPHIC)
                         || parentContainerMask.isAcceptingAccessory(Accessory.ROOT)
+                        || parentContainerMask.isAcceptingAccessory(Accessory.SCENE)
                         || parentContainerMask.getFxomObject().getSceneGraphObject() instanceof BorderPane
                         || parentContainerMask.getFxomObject().getSceneGraphObject() instanceof DialogPane;
                 return childrenCount == 1;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/UnwrapJob.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/UnwrapJob.java
@@ -126,6 +126,7 @@ public class UnwrapJob extends BatchSelectionJob {
             } else {
                 assert parentContainerMask.isAcceptingAccessory(Accessory.CONTENT)
                         || parentContainerMask.isAcceptingAccessory(Accessory.GRAPHIC)
+                        || parentContainerMask.isAcceptingAccessory(Accessory.ROOT)
                         || parentContainerMask.getFxomObject().getSceneGraphObject() instanceof BorderPane
                         || parentContainerMask.getFxomObject().getSceneGraphObject() instanceof DialogPane;
                 return childrenCount == 1;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/WrapJobUtils.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/WrapJobUtils.java
@@ -122,6 +122,8 @@ public class WrapJobUtils {
                 assert false;
                 result = null;
             }
+        } else if (mask.isAcceptingAccessory(Accessory.SCENE)) {
+            result = mask.getPropertyNameForAccessory(Accessory.SCENE);
         } else if (mask.isAcceptingAccessory(Accessory.ROOT)) {
             result = mask.getPropertyNameForAccessory(Accessory.ROOT);
         } else if (mask.isAcceptingSubComponent()) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/WrapJobUtils.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/job/wrap/WrapJobUtils.java
@@ -122,6 +122,8 @@ public class WrapJobUtils {
                 assert false;
                 result = null;
             }
+        } else if (mask.isAcceptingAccessory(Accessory.ROOT)) {
+            result = mask.getPropertyNameForAccessory(Accessory.ROOT);
         } else if (mask.isAcceptingSubComponent()) {
             result = mask.getSubComponentPropertyName();
         } else {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -48,6 +48,7 @@ import javafx.fxml.FXML;
 import javafx.geometry.Bounds;
 import javafx.scene.Group;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.Accordion;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
@@ -88,6 +89,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform;
 import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform.Theme;
 import com.oracle.javafx.scenebuilder.kit.editor.drag.source.AbstractDragSource;
 import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AbstractDropTarget;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.SceneDriver;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.AbstractDriver;
@@ -984,6 +986,8 @@ public class ContentPanelController extends AbstractFxmlPanelController
             result = new TreeTableColumnDriver(this);
         } else if (sceneGraphObject instanceof Node) {
             result = new GenericDriver(this);
+        } else if (sceneGraphObject instanceof Scene) {
+            result = new SceneDriver(this);
         } else {
             result = null;
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -90,6 +90,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.EditorPlatform.Theme;
 import com.oracle.javafx.scenebuilder.kit.editor.drag.source.AbstractDragSource;
 import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AbstractDropTarget;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.SceneDriver;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.WindowDriver;
 import com.oracle.javafx.scenebuilder.kit.i18n.I18N;
 import com.oracle.javafx.scenebuilder.kit.editor.images.ImageUtils;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.AbstractDriver;
@@ -126,6 +127,7 @@ import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.DesignHierarchyMask;
 import javafx.scene.SubScene;
+import javafx.stage.Window;
 
 /**
  * This class creates and controls the <b>Content Panel</b> of Scene Builder Kit.
@@ -988,6 +990,8 @@ public class ContentPanelController extends AbstractFxmlPanelController
             result = new GenericDriver(this);
         } else if (sceneGraphObject instanceof Scene) {
             result = new SceneDriver(this);
+        } else if (sceneGraphObject instanceof Window) {
+            result = new WindowDriver(this);
         } else {
             result = null;
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/ContentPanelController.java
@@ -442,14 +442,7 @@ public class ContentPanelController extends AbstractFxmlPanelController
         
         if (isContentDisplayable()) {
             final FXOMDocument fxomDocument = getEditorController().getFxomDocument();
-            assert fxomDocument != null;
-            if ((fxomDocument.getFxomRoot() == null) 
-                    || excludes.contains(fxomDocument.getFxomRoot())) {
-                result = null;
-            } else {
-                assert fxomDocument.getFxomRoot().getSceneGraphObject() instanceof Node;
-                result = pick(fxomDocument.getFxomRoot(), sceneX, sceneY, excludes);
-            }
+            result = pick(fxomDocument, sceneX, sceneY, excludes);
         } else {
             result = null;
         }
@@ -457,6 +450,28 @@ public class ContentPanelController extends AbstractFxmlPanelController
         return result;
     }
     
+    public FXOMObject pick(FXOMDocument fxomDocument, double sceneX, double sceneY, Set<FXOMObject> excludes) {
+        assert fxomDocument != null;
+
+        if (fxomDocument.getFxomRoot() == null) {
+            return null;
+        }
+
+        Node displayNode = fxomDocument.getDisplayNode();
+        if (displayNode != null) {
+            FXOMObject startObject = fxomDocument.getFxomRoot().searchWithSceneGraphObject(displayNode);
+            if (startObject == null || excludes.contains(startObject)) {
+                return null;
+            }
+            return pick(startObject, sceneX, sceneY, excludes);
+        }
+
+        if (excludes.contains(fxomDocument.getFxomRoot())) {
+            return null;
+        }
+
+        return pick(fxomDocument.getFxomRoot(), sceneX, sceneY, excludes);
+    }
     
     /**
      * Returns the topmost FXOMObject at (sceneX, sceneY) but ignoring
@@ -713,7 +728,7 @@ public class ContentPanelController extends AbstractFxmlPanelController
         } else if (fxomDocument.getFxomRoot() == null) {
             result = true;
         } else {
-            result = fxomDocument.getFxomRoot().isNode()
+            result = fxomDocument.getDisplayNodeOrSceneGraphRoot() instanceof Node
                     && workspaceController.getLayoutException() == null;
         }
         

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/WorkspaceController.java
@@ -332,7 +332,7 @@ class WorkspaceController {
             statusMessageText = I18N.getString("content.label.status.invitation");
             statusStyleClass = "stage-prompt"; //NOI18N
         } else {
-            final Object userSceneGraph = fxomDocument.getSceneGraphRoot();
+            final Object userSceneGraph = fxomDocument.getDisplayNodeOrSceneGraphRoot();
             if (userSceneGraph instanceof Node) {
                 final Node rootNode = (Node) userSceneGraph;
                 assert rootNode.getParent() == null;
@@ -393,7 +393,7 @@ class WorkspaceController {
         if (fxomDocument == null) {
             userSceneGraph = null;
         } else {
-            userSceneGraph = fxomDocument.getSceneGraphRoot();
+            userSceneGraph = fxomDocument.getDisplayNodeOrSceneGraphRoot();
         }
         if ((userSceneGraph instanceof Node) && (layoutException == null)) {
             final Node rootNode = (Node) userSceneGraph;

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/SceneDriver.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/SceneDriver.java
@@ -1,0 +1,84 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver;
+
+import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AbstractDropTarget;
+import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AccessoryDropTarget;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles.AbstractHandles;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles.SceneHandles;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.pring.AbstractPring;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.pring.NodePring;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.resizer.AbstractResizer;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.tring.AbstractTring;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMProperty;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyC;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.DesignHierarchyMask;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
+
+import javafx.geometry.Bounds;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+
+public class SceneDriver extends AbstractDriver {
+    public SceneDriver(ContentPanelController contentPanelController) {
+        super(contentPanelController);
+    }
+
+    @Override
+    public AbstractHandles<?> makeHandles(FXOMObject fxomObject) {
+        assert fxomObject.getSceneGraphObject() instanceof Scene;
+        assert fxomObject instanceof FXOMInstance;
+        return new SceneHandles(contentPanelController, (FXOMInstance) fxomObject);
+    }
+
+    @Override
+    public AbstractTring<?> makeTring(AbstractDropTarget dropTarget) {
+        return null;
+    }
+
+    @Override
+    public AbstractPring<?> makePring(FXOMObject fxomObject) {
+        assert fxomObject.getSceneGraphObject() instanceof Scene;
+        DesignHierarchyMask designHierarchyMask = new DesignHierarchyMask(fxomObject);
+        FXOMObject root = designHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root.getSceneGraphObject() instanceof Node;
+        assert root instanceof FXOMInstance;
+        return new NodePring(contentPanelController, (FXOMInstance) root);
+    }
+
+    @Override
+    public AbstractResizer<?> makeResizer(FXOMObject fxomObject) {
+        // Resize gesture does not apply to Scenes
+        return null;
+    }
+
+    @Override
+    public FXOMObject refinePick(Node hitNode, double sceneX, double sceneY, FXOMObject fxomObject) {
+        return fxomObject;
+    }
+
+    @Override
+    public AbstractDropTarget makeDropTarget(FXOMObject fxomObject, double sceneX, double sceneY) {
+        assert fxomObject instanceof FXOMInstance;
+        return new AccessoryDropTarget((FXOMInstance) fxomObject, DesignHierarchyMask.Accessory.ROOT);
+    }
+
+    @Override
+    public Node getInlineEditorBounds(FXOMObject fxomObject) {
+        return null;
+    }
+
+    @Override
+    public boolean intersectsBounds(FXOMObject fxomObject, Bounds bounds) {
+        assert fxomObject.getSceneGraphObject() instanceof Scene;
+        DesignHierarchyMask designHierarchyMask = new DesignHierarchyMask(fxomObject);
+        FXOMObject root = designHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root.getSceneGraphObject() instanceof Node;
+        Node rootNode = (Node) root.getSceneGraphObject();
+        final Bounds rootNodeBounds = rootNode.localToScene(rootNode.getLayoutBounds(), true /* rootScene */);
+        return rootNodeBounds.intersects(bounds);
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/WindowDriver.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/WindowDriver.java
@@ -1,0 +1,95 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver;
+
+import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AbstractDropTarget;
+import com.oracle.javafx.scenebuilder.kit.editor.drag.target.AccessoryDropTarget;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles.AbstractHandles;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles.WindowHandles;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.pring.AbstractPring;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.pring.NodePring;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.resizer.AbstractResizer;
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.tring.AbstractTring;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.DesignHierarchyMask;
+
+import javafx.geometry.Bounds;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.stage.Window;
+
+public class WindowDriver extends AbstractDriver {
+
+    public WindowDriver(ContentPanelController contentPanelController) {
+        super(contentPanelController);
+    }
+
+    @Override
+    public AbstractHandles<?> makeHandles(FXOMObject fxomObject) {
+        assert fxomObject.getSceneGraphObject() instanceof Window;
+        assert fxomObject instanceof FXOMInstance;
+        return new WindowHandles(contentPanelController, (FXOMInstance) fxomObject);
+    }
+
+    @Override
+    public AbstractTring<?> makeTring(AbstractDropTarget dropTarget) {
+        return null;
+    }
+
+    @Override
+    public AbstractPring<?> makePring(FXOMObject fxomObject) {
+        assert fxomObject.getSceneGraphObject() instanceof Window;
+        DesignHierarchyMask windowDesignHierarchyMask = new DesignHierarchyMask(fxomObject);
+        FXOMObject scene = windowDesignHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.SCENE);
+        assert scene != null : "makePring should have only been called if the Window has a scene";
+        assert scene.getSceneGraphObject() instanceof Scene;
+        assert scene instanceof FXOMInstance;
+        DesignHierarchyMask sceneDesignHierarchyMask = new DesignHierarchyMask(scene);
+        FXOMObject root = sceneDesignHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root.getSceneGraphObject() instanceof Node;
+        assert root instanceof FXOMInstance;
+        return new NodePring(contentPanelController, (FXOMInstance) root);
+    }
+
+    @Override
+    public AbstractResizer<?> makeResizer(FXOMObject fxomObject) {
+        // Resize gesture does not apply to Windows
+        return null;
+    }
+
+    @Override
+    public FXOMObject refinePick(Node hitNode, double sceneX, double sceneY, FXOMObject fxomObject) {
+        return fxomObject;
+    }
+
+    @Override
+    public AbstractDropTarget makeDropTarget(FXOMObject fxomObject, double sceneX, double sceneY) {
+        assert fxomObject instanceof FXOMInstance;
+        return new AccessoryDropTarget((FXOMInstance) fxomObject, DesignHierarchyMask.Accessory.SCENE);
+    }
+
+    @Override
+    public Node getInlineEditorBounds(FXOMObject fxomObject) {
+        return null;
+    }
+
+    @Override
+    public boolean intersectsBounds(FXOMObject fxomObject, Bounds bounds) {
+        assert fxomObject.getSceneGraphObject() instanceof Window;
+        DesignHierarchyMask windowDesignHierarchyMask = new DesignHierarchyMask(fxomObject);
+        FXOMObject scene = windowDesignHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.SCENE);
+        if (scene == null) {
+            return false;
+        }
+        assert scene.getSceneGraphObject() instanceof Scene;
+        assert scene instanceof FXOMInstance;
+        DesignHierarchyMask sceneDesignHierarchyMask = new DesignHierarchyMask(scene);
+        FXOMObject root = sceneDesignHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root.getSceneGraphObject() instanceof Node;
+        Node rootNode = (Node) root.getSceneGraphObject();
+        Bounds rootNodeBounds = rootNode.localToScene(rootNode.getLayoutBounds(), true /* rootScene */);
+        return rootNodeBounds.intersects(bounds);
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/handles/SceneHandles.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/handles/SceneHandles.java
@@ -1,0 +1,54 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles;
+
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.DesignHierarchyMask;
+
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Bounds;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+
+public class SceneHandles extends AbstractGenericHandles<Scene> {
+    private final DesignHierarchyMask designHierarchyMask;
+
+    public SceneHandles(ContentPanelController contentPanelController,
+                        FXOMInstance fxomInstance) {
+        super(contentPanelController, fxomInstance, Scene.class);
+        designHierarchyMask = new DesignHierarchyMask(getFxomObject());
+    }
+
+    @Override
+    public Bounds getSceneGraphObjectBounds() {
+        return getSceneRoot().getLayoutBounds();
+    }
+
+    @Override
+    public Node getSceneGraphObjectProxy() {
+        return getSceneRoot();
+    }
+
+    @Override
+    protected void startListeningToSceneGraphObject() {
+        Node sceneRoot = getSceneRoot();
+        startListeningToLayoutBounds(sceneRoot);
+        startListeningToLocalToSceneTransform(sceneRoot);
+    }
+
+    @Override
+    protected void stopListeningToSceneGraphObject() {
+        Node sceneRoot = getSceneRoot();
+        stopListeningToLayoutBounds(sceneRoot);
+        stopListeningToLocalToSceneTransform(sceneRoot);
+    }
+
+    private Node getSceneRoot() {
+        FXOMObject root = designHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root instanceof FXOMInstance;
+        assert root.getSceneGraphObject() instanceof Node;
+        return (Node) root.getSceneGraphObject();
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/handles/WindowHandles.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/driver/handles/WindowHandles.java
@@ -1,0 +1,68 @@
+package com.oracle.javafx.scenebuilder.kit.editor.panel.content.driver.handles;
+
+import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMInstance;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.metadata.util.DesignHierarchyMask;
+
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Bounds;
+import javafx.scene.Node;
+import javafx.scene.layout.Pane;
+import javafx.stage.Window;
+
+public class WindowHandles extends AbstractGenericHandles<Window> {
+    private final DesignHierarchyMask designHierarchyMask;
+    private final Pane dummyPane = new Pane();
+
+    public WindowHandles(ContentPanelController contentPanelController,
+                         FXOMInstance fxomInstance) {
+        super(contentPanelController, fxomInstance, Window.class);
+        designHierarchyMask = new DesignHierarchyMask(fxomInstance);
+    }
+
+    @Override
+    public Bounds getSceneGraphObjectBounds() {
+        Node sceneRoot = getSceneRoot();
+        return sceneRoot != null ? sceneRoot.getLayoutBounds() : new BoundingBox(0, 0, 0, 0);
+    }
+
+    @Override
+    public Node getSceneGraphObjectProxy() {
+        Node sceneRoot = getSceneRoot();
+        return sceneRoot != null ? sceneRoot : dummyPane;
+    }
+
+    @Override
+    protected void startListeningToSceneGraphObject() {
+        Node sceneRoot = getSceneRoot();
+        if (sceneRoot == null) {
+            return;
+        }
+        startListeningToLayoutBounds(sceneRoot);
+        startListeningToLocalToSceneTransform(sceneRoot);
+    }
+
+    @Override
+    protected void stopListeningToSceneGraphObject() {
+        Node sceneRoot = getSceneRoot();
+        if (sceneRoot == null) {
+            return;
+        }
+        stopListeningToLayoutBounds(sceneRoot);
+        stopListeningToLocalToSceneTransform(sceneRoot);
+    }
+
+    private Node getSceneRoot() {
+        FXOMObject scene = designHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.SCENE);
+        if (scene == null) {
+            return null;
+        }
+        DesignHierarchyMask sceneDesignHierarchyMask = new DesignHierarchyMask(scene);
+        FXOMObject root = sceneDesignHierarchyMask.getAccessory(DesignHierarchyMask.Accessory.ROOT);
+        assert root != null;
+        assert root instanceof FXOMInstance;
+        assert root.getSceneGraphObject() instanceof Node;
+        return (Node) root.getSceneGraphObject();
+    }
+}

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/gesture/mouse/SelectAndMoveGesture.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/content/gesture/mouse/SelectAndMoveGesture.java
@@ -37,6 +37,7 @@ import com.oracle.javafx.scenebuilder.kit.editor.drag.source.DocumentDragSource;
 import com.oracle.javafx.scenebuilder.kit.editor.panel.content.ContentPanelController;
 import com.oracle.javafx.scenebuilder.kit.editor.selection.ObjectSelectionGroup;
 import com.oracle.javafx.scenebuilder.kit.editor.selection.Selection;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
@@ -196,9 +197,16 @@ public class SelectAndMoveGesture extends AbstractMouseDragGesture {
     private Point2D computeHitPoint(FXOMObject fxomObject) {
         
         final FXOMObject nodeObject = fxomObject.getClosestNode();
-        assert nodeObject != null; // At least the root is a Node
-        assert nodeObject.getSceneGraphObject() instanceof Node;
-        final Node sceneGraphNode = (Node) nodeObject.getSceneGraphObject();
+        final Node sceneGraphNode;
+        if (nodeObject == null) {
+            // Root object is not a node, there should be a display node
+            FXOMDocument document = fxomObject.getFxomDocument();
+            assert document.getDisplayNode() != null;
+            sceneGraphNode = document.getDisplayNode();
+        } else {
+            assert nodeObject.getSceneGraphObject() instanceof Node;
+            sceneGraphNode = (Node) nodeObject.getSceneGraphObject();
+        }
         return sceneGraphNode.sceneToLocal(hitSceneX, hitSceneY, true /* rootScene */);
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/AbstractHierarchyPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/AbstractHierarchyPanelController.java
@@ -903,6 +903,13 @@ public abstract class AbstractHierarchyPanelController extends AbstractFxmlPanel
             }
         }
 
+        if (mask.isAcceptingAccessory(Accessory.SCENE)) {
+            final FXOMObject value = mask.getAccessory(Accessory.SCENE);
+            if (value != null) {
+                treeItem.getChildren().add(makeTreeItem(value));
+            }
+        }
+
         // Positionning
         //---------------------------------
         for (Accessory accessory : new Accessory[]{

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/AbstractHierarchyPanelController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/AbstractHierarchyPanelController.java
@@ -896,6 +896,13 @@ public abstract class AbstractHierarchyPanelController extends AbstractFxmlPanel
             }
         }
 
+        if (mask.isAcceptingAccessory(Accessory.ROOT)) {
+            final FXOMObject value = mask.getAccessory(Accessory.ROOT);
+            if (value != null) {
+                treeItem.getChildren().add(makeTreeItem(value));
+            }
+        }
+
         // Positionning
         //---------------------------------
         for (Accessory accessory : new Accessory[]{

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/HierarchyDNDController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/editor/panel/hierarchy/HierarchyDNDController.java
@@ -447,7 +447,8 @@ public class HierarchyDNDController {
                         Accessory.HEADER,
                         Accessory.DP_GRAPHIC,
                         Accessory.DP_CONTENT,
-                        Accessory.EXPANDABLE_CONTENT
+                        Accessory.EXPANDABLE_CONTENT,
+                        Accessory.SCENE
                     };
                     for (Accessory a : accessories) {
                         final AccessoryDropTarget dropTarget

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
@@ -53,6 +53,8 @@ import com.oracle.javafx.scenebuilder.kit.fxom.sampledata.SampleDataGenerator;
 import com.oracle.javafx.scenebuilder.kit.util.Deprecation;
 import com.oracle.javafx.scenebuilder.kit.util.URLUtils;
 import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
 
 /**
  *

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
@@ -67,6 +67,7 @@ public class FXOMDocument {
     private SampleDataGenerator sampleDataGenerator;
     private FXOMObject fxomRoot;
     private Object sceneGraphRoot;
+    private Node displayNode;
     private final SimpleIntegerProperty sceneGraphRevision = new SimpleIntegerProperty();
     private final SimpleIntegerProperty cssRevision = new SimpleIntegerProperty();
     private SceneGraphHolder sceneGraphHolder;
@@ -195,6 +196,7 @@ public class FXOMDocument {
             this.glue.setRootElement(this.fxomRoot.getGlueElement());
         }
         this.sceneGraphRoot = sceneGraphRoot;
+        this.displayNode = null;
     }
 
     public Object getSceneGraphRoot() {
@@ -203,6 +205,27 @@ public class FXOMDocument {
 
     void setSceneGraphRoot(Object sceneGraphRoot) {
         this.sceneGraphRoot = sceneGraphRoot;
+    }
+
+    /**
+     * Returns the Node that should be displayed in the editor instead of the scene graph root.
+     */
+    public Node getDisplayNode() {
+        return displayNode;
+    }
+
+    /**
+     * Sets the Node that should be displayed in the editor instead of the scene graph root.
+     */
+    void setDisplayNode(Node displayNode) {
+        this.displayNode = displayNode;
+    }
+
+    /**
+     * Returns the display node if one is set, otherwise returns the scene graph root.
+     */
+    public Object getDisplayNodeOrSceneGraphRoot() {
+        return displayNode != null ? displayNode : sceneGraphRoot;
     }
 
     public String getFxmlText() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
@@ -39,7 +39,9 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -71,6 +73,7 @@ public class FXOMDocument {
     private FXOMObject fxomRoot;
     private Object sceneGraphRoot;
     private Node displayNode;
+    private ArrayList<String> displayStylesheets = new ArrayList<>();
     private final SimpleIntegerProperty sceneGraphRevision = new SimpleIntegerProperty();
     private final SimpleIntegerProperty cssRevision = new SimpleIntegerProperty();
     private SceneGraphHolder sceneGraphHolder;
@@ -200,6 +203,7 @@ public class FXOMDocument {
         }
         this.sceneGraphRoot = sceneGraphRoot;
         this.displayNode = null;
+        this.displayStylesheets.clear();
     }
 
     public Object getSceneGraphRoot() {
@@ -215,6 +219,15 @@ public class FXOMDocument {
      */
     public Node getDisplayNode() {
         return displayNode;
+    }
+
+    public List<String> getDisplayStylesheets() {
+        return Collections.unmodifiableList(displayStylesheets);
+    }
+
+    void setDisplayStylesheets(List<String> displayStylesheets) {
+        this.displayStylesheets.clear();
+        this.displayStylesheets.addAll(displayStylesheets);
     }
 
     /**

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMDocument.java
@@ -55,6 +55,7 @@ import com.oracle.javafx.scenebuilder.kit.util.URLUtils;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
+import javafx.stage.Window;
 
 /**
  *

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
@@ -38,6 +38,7 @@ import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
 import com.oracle.javafx.scenebuilder.kit.util.Deprecation;
 import com.sun.javafx.fxml.LoadListener;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
@@ -90,7 +91,7 @@ class FXOMLoader implements LoadListener {
             currentTransientNode = null;
             assert is.markSupported();
             is.reset();
-            document.setSceneGraphRoot(fxmlLoader.load(is));
+            setSceneGraphRoot(fxmlLoader.load(is));
         } catch (RuntimeException | IOException x) {
             if (x.getCause().getClass() == XMLStreamException.class) {
                 handleUnsupportedCharset(x);
@@ -106,6 +107,11 @@ class FXOMLoader implements LoadListener {
         errorDialog.setDebugInfo(x.getCause().toString());
         errorDialog.setTitle(I18N.getString("alert.title.open"));
         errorDialog.showAndWait();
+    }
+
+    private void setSceneGraphRoot(Object sceneGraphRoot) {
+        document.setSceneGraphRoot(sceneGraphRoot);
+        document.setDisplayNode(null);
     }
 
     public FXOMDocument getDocument() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
@@ -39,6 +39,8 @@ import com.oracle.javafx.scenebuilder.kit.util.Deprecation;
 import com.sun.javafx.fxml.LoadListener;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
@@ -112,6 +114,12 @@ class FXOMLoader implements LoadListener {
     private void setSceneGraphRoot(Object sceneGraphRoot) {
         document.setSceneGraphRoot(sceneGraphRoot);
         document.setDisplayNode(null);
+
+        if (sceneGraphRoot instanceof Scene) {
+            Scene scene = (Scene) sceneGraphRoot;
+            document.setDisplayNode(scene.getRoot());
+            scene.setRoot(new Pane()); // ensure displayNode is only part of one scene
+        }
     }
 
     public FXOMDocument getDocument() {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
@@ -41,6 +41,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
+import javafx.stage.Window;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
@@ -119,6 +120,12 @@ class FXOMLoader implements LoadListener {
             Scene scene = (Scene) sceneGraphRoot;
             document.setDisplayNode(scene.getRoot());
             scene.setRoot(new Pane()); // ensure displayNode is only part of one scene
+        } else if (sceneGraphRoot instanceof Window) {
+            Window window = (Window) sceneGraphRoot;
+            if (window.getScene() != null) {
+                document.setDisplayNode(window.getScene().getRoot());
+                window.getScene().setRoot(new Pane()); // ensure displayNode is only part of one scene
+            }
         }
     }
 

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMLoader.java
@@ -48,6 +48,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Collections;
 
 
 /**
@@ -115,15 +116,18 @@ class FXOMLoader implements LoadListener {
     private void setSceneGraphRoot(Object sceneGraphRoot) {
         document.setSceneGraphRoot(sceneGraphRoot);
         document.setDisplayNode(null);
+        document.setDisplayStylesheets(Collections.emptyList());
 
         if (sceneGraphRoot instanceof Scene) {
             Scene scene = (Scene) sceneGraphRoot;
             document.setDisplayNode(scene.getRoot());
+            document.setDisplayStylesheets(scene.getStylesheets());
             scene.setRoot(new Pane()); // ensure displayNode is only part of one scene
         } else if (sceneGraphRoot instanceof Window) {
             Window window = (Window) sceneGraphRoot;
             if (window.getScene() != null) {
                 document.setDisplayNode(window.getScene().getRoot());
+                document.setDisplayStylesheets(window.getScene().getStylesheets());
                 window.getScene().setRoot(new Pane()); // ensure displayNode is only part of one scene
             }
         }

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -110,6 +110,8 @@ class FXOMRefresher {
     private void refreshDocument(FXOMDocument currentDocument, FXOMDocument newDocument) {
         // Transfers scene graph object from newDocument to currentDocument
         currentDocument.setSceneGraphRoot(newDocument.getSceneGraphRoot());
+        // Transfers display node from newDocument to currentDocument
+        currentDocument.setDisplayNode(newDocument.getDisplayNode());
         // Simulates Scene's behavior : automatically adds "root" styleclass if
         // if the scene graph root is a Parent instance
         if (currentDocument.getSceneGraphRoot() instanceof Parent) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -46,6 +46,7 @@ import javafx.stage.Window;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -116,6 +117,8 @@ class FXOMRefresher {
         currentDocument.setSceneGraphRoot(newDocument.getSceneGraphRoot());
         // Transfers display node from newDocument to currentDocument
         currentDocument.setDisplayNode(newDocument.getDisplayNode());
+        // Transfers display stylesheets from newDocument to currentDocument
+        currentDocument.setDisplayStylesheets(newDocument.getDisplayStylesheets());
         // Simulates Scene's behavior : automatically adds "root" styleclass if
         // if the scene graph root is a Parent instance or wraps a Parent instance
         if (currentDocument.getSceneGraphRoot() instanceof Parent) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -41,6 +41,7 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.SplitPane;
+import javafx.stage.Window;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,7 +121,8 @@ class FXOMRefresher {
         if (currentDocument.getSceneGraphRoot() instanceof Parent) {
             final Parent rootParent = (Parent) currentDocument.getSceneGraphRoot();
             rootParent.getStyleClass().add(0, "root");
-        } else if (currentDocument.getSceneGraphRoot() instanceof Scene) {
+        } else if (currentDocument.getSceneGraphRoot() instanceof Scene
+                || currentDocument.getSceneGraphRoot() instanceof Window) {
             Node displayNode = currentDocument.getDisplayNode();
             if (displayNode != null && displayNode instanceof Parent) {
                 displayNode.getStyleClass().add(0, "root");

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/fxom/FXOMRefresher.java
@@ -36,7 +36,10 @@ import com.oracle.javafx.scenebuilder.kit.metadata.property.ValuePropertyMetadat
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.DoubleArrayPropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.property.value.list.ListValuePropertyMetadata;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
+
+import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.SplitPane;
 
 import java.io.File;
@@ -113,10 +116,15 @@ class FXOMRefresher {
         // Transfers display node from newDocument to currentDocument
         currentDocument.setDisplayNode(newDocument.getDisplayNode());
         // Simulates Scene's behavior : automatically adds "root" styleclass if
-        // if the scene graph root is a Parent instance
+        // if the scene graph root is a Parent instance or wraps a Parent instance
         if (currentDocument.getSceneGraphRoot() instanceof Parent) {
             final Parent rootParent = (Parent) currentDocument.getSceneGraphRoot();
             rootParent.getStyleClass().add(0, "root");
+        } else if (currentDocument.getSceneGraphRoot() instanceof Scene) {
+            Node displayNode = currentDocument.getDisplayNode();
+            if (displayNode != null && displayNode instanceof Parent) {
+                displayNode.getStyleClass().add(0, "root");
+            }
         }
         // Recurses
         if (currentDocument.getFxomRoot() != null) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
@@ -247,6 +247,7 @@ public class BuiltinLibrary extends Library {
         addDefaultItem(javafx.scene.Group.class, TAG_MISCELLANEOUS);
         addRegionItem200x200(javafx.scene.layout.Region.class, TAG_MISCELLANEOUS);
         addCustomizedItem(javafx.scene.Scene.class, TAG_MISCELLANEOUS, "Scene", "MissingIcon", null);
+        addCustomizedItem(javafx.stage.Stage.class, TAG_MISCELLANEOUS, "Stage", "MissingIcon", null);
         addCustomizedItem(javafx.scene.SubScene.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
         addDefaultItem(javafx.embed.swing.SwingNode.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
         addCustomizedItem(javafx.scene.control.Tooltip.class, TAG_MISCELLANEOUS);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/library/BuiltinLibrary.java
@@ -246,6 +246,7 @@ public class BuiltinLibrary extends Library {
         addCustomizedItem(javafx.scene.canvas.Canvas.class, TAG_MISCELLANEOUS);
         addDefaultItem(javafx.scene.Group.class, TAG_MISCELLANEOUS);
         addRegionItem200x200(javafx.scene.layout.Region.class, TAG_MISCELLANEOUS);
+        addCustomizedItem(javafx.scene.Scene.class, TAG_MISCELLANEOUS, "Scene", "MissingIcon", null);
         addCustomizedItem(javafx.scene.SubScene.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
         addDefaultItem(javafx.embed.swing.SwingNode.class, TAG_MISCELLANEOUS, FX8_QUALIFIER);
         addCustomizedItem(javafx.scene.control.Tooltip.class, TAG_MISCELLANEOUS);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/Metadata.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/Metadata.java
@@ -55,6 +55,8 @@ import com.oracle.javafx.scenebuilder.kit.metadata.property.value.paint.PaintPro
 import com.oracle.javafx.scenebuilder.kit.metadata.util.InspectorPath;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.InspectorPathComparator;
 import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
+
+import javafx.scene.Scene;
 import javafx.scene.control.SelectionMode;
 
 import java.util.ArrayList;
@@ -400,6 +402,8 @@ public class Metadata {
             new ComponentClassMetadata(javafx.scene.control.RadioButton.class, ToggleButtonMetadata);
     private final ComponentClassMetadata RadioMenuItemMetadata = 
             new ComponentClassMetadata(javafx.scene.control.RadioMenuItem.class, MenuItemMetadata);
+    private final ComponentClassMetadata SceneMetadata =
+            new ComponentClassMetadata(Scene.class, null);
     private final ComponentClassMetadata ScrollBarMetadata = 
             new ComponentClassMetadata(javafx.scene.control.ScrollBar.class, ControlMetadata);
     private final ComponentClassMetadata ScrollPaneMetadata = 
@@ -1058,6 +1062,8 @@ public class Metadata {
             new PropertyName("resizable");
     private final PropertyName rightName = 
             new PropertyName("right");
+    private final PropertyName rootName =
+            new PropertyName("root");
     private final PropertyName rotateName = 
             new PropertyName("rotate");
     private final PropertyName rotateGraphicName = 
@@ -2247,6 +2253,12 @@ public class Metadata {
                 fillName,
                 true, /* readWrite */
                 javafx.scene.paint.Color.BLACK, /* defaultValue */
+                new InspectorPath("Properties", "Specific", 20));
+    private final ValuePropertyMetadata fill_WHITE_PropertyMetadata =
+            new PaintPropertyMetadata(
+                fillName,
+                true, /* readWrite */
+                javafx.scene.paint.Color.WHITE, /* defaultValue */
                 new InspectorPath("Properties", "Specific", 20));
     private final ValuePropertyMetadata fillHeightPropertyMetadata =
             new BooleanPropertyMetadata(
@@ -3461,6 +3473,11 @@ public class Metadata {
                 rightName,
                 NodeMetadata,
                 false); /* collection */
+    private final ComponentPropertyMetadata root_scene_PropertyMetadata =
+            new ComponentPropertyMetadata(
+                    rootName,
+                    NodeMetadata,
+                    false);
     private final ValuePropertyMetadata rotatePropertyMetadata =
             new DoublePropertyMetadata(
                 rotateName,
@@ -4869,6 +4886,7 @@ public class Metadata {
         componentClassMap.put(RowConstraintsMetadata.getKlass(), RowConstraintsMetadata);
         componentClassMap.put(SVGPathMetadata.getKlass(), SVGPathMetadata);
         componentClassMap.put(ScatterChartMetadata.getKlass(), ScatterChartMetadata);
+        componentClassMap.put(SceneMetadata.getKlass(), SceneMetadata);
         componentClassMap.put(ScrollBarMetadata.getKlass(), ScrollBarMetadata);
         componentClassMap.put(ScrollPaneMetadata.getKlass(), ScrollPaneMetadata);
         componentClassMap.put(SeparatorMetadata.getKlass(), SeparatorMetadata);
@@ -5593,6 +5611,49 @@ public class Metadata {
         SVGPathMetadata.getProperties().add(pickOnBounds_false_PropertyMetadata);
 
         ScatterChartMetadata.getProperties().add(styleClass_c37_PropertyMetadata);
+
+        SceneMetadata.getProperties().add(fill_WHITE_PropertyMetadata);
+        SceneMetadata.getProperties().add(onContextMenuRequestedPropertyMetadata);
+        SceneMetadata.getProperties().add(onDragDetectedPropertyMetadata);
+        SceneMetadata.getProperties().add(onDragDonePropertyMetadata);
+        SceneMetadata.getProperties().add(onDragDroppedPropertyMetadata);
+        SceneMetadata.getProperties().add(onDragEnteredPropertyMetadata);
+        SceneMetadata.getProperties().add(onDragExitedPropertyMetadata);
+        SceneMetadata.getProperties().add(onDragOverPropertyMetadata);
+        SceneMetadata.getProperties().add(onInputMethodTextChangedPropertyMetadata);
+        SceneMetadata.getProperties().add(onKeyPressedPropertyMetadata);
+        SceneMetadata.getProperties().add(onKeyReleasedPropertyMetadata);
+        SceneMetadata.getProperties().add(onKeyTypedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseClickedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseDragEnteredPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseDragExitedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseDraggedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseDragOverPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseDragReleasedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseEnteredPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseExitedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseMovedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMousePressedPropertyMetadata);
+        SceneMetadata.getProperties().add(onMouseReleasedPropertyMetadata);
+        SceneMetadata.getProperties().add(onRotatePropertyMetadata);
+        SceneMetadata.getProperties().add(onRotationFinishedPropertyMetadata);
+        SceneMetadata.getProperties().add(onRotationStartedPropertyMetadata);
+        SceneMetadata.getProperties().add(onScrollFinishedPropertyMetadata);
+        SceneMetadata.getProperties().add(onScrollPropertyMetadata);
+        SceneMetadata.getProperties().add(onScrollStartedPropertyMetadata);
+        SceneMetadata.getProperties().add(onSwipeDownPropertyMetadata);
+        SceneMetadata.getProperties().add(onSwipeLeftPropertyMetadata);
+        SceneMetadata.getProperties().add(onSwipeRightPropertyMetadata);
+        SceneMetadata.getProperties().add(onSwipeUpPropertyMetadata);
+        SceneMetadata.getProperties().add(onTouchMovedPropertyMetadata);
+        SceneMetadata.getProperties().add(onTouchPressedPropertyMetadata);
+        SceneMetadata.getProperties().add(onTouchReleasedPropertyMetadata);
+        SceneMetadata.getProperties().add(onTouchStationaryPropertyMetadata);
+        SceneMetadata.getProperties().add(onZoomFinishedPropertyMetadata);
+        SceneMetadata.getProperties().add(onZoomPropertyMetadata);
+        SceneMetadata.getProperties().add(onZoomStartedPropertyMetadata);
+        SceneMetadata.getProperties().add(root_scene_PropertyMetadata);
+        SceneMetadata.getProperties().add(stylesheetsPropertyMetadata);
 
         ScrollBarMetadata.getProperties().add(accessibleRole_SCROLL_BAR_PropertyMetadata);
         ScrollBarMetadata.getProperties().add(blockIncrementPropertyMetadata);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/Metadata.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/Metadata.java
@@ -58,6 +58,8 @@ import com.oracle.javafx.scenebuilder.kit.metadata.util.PropertyName;
 
 import javafx.scene.Scene;
 import javafx.scene.control.SelectionMode;
+import javafx.stage.Stage;
+import javafx.stage.Window;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -303,6 +305,8 @@ public class Metadata {
             new ComponentClassMetadata(javafx.scene.LightBase.class, NodeMetadata);
     private final ComponentClassMetadata Shape3DMetadata = 
             new ComponentClassMetadata(javafx.scene.shape.Shape3D.class, NodeMetadata);
+    private final ComponentClassMetadata WindowMetadata =
+            new ComponentClassMetadata(Window.class, null);
 
 
 
@@ -420,6 +424,8 @@ public class Metadata {
             new ComponentClassMetadata(javafx.scene.control.SplitMenuButton.class, MenuButtonMetadata);
     private final ComponentClassMetadata SplitPaneMetadata = 
             new ComponentClassMetadata(javafx.scene.control.SplitPane.class, ControlMetadata);
+    private final ComponentClassMetadata StageMetadata =
+            new ComponentClassMetadata(Stage.class, WindowMetadata);
     private final ComponentClassMetadata TabMetadata = 
             new ComponentClassMetadata(javafx.scene.control.Tab.class, null);
     private final ComponentClassMetadata TabPaneMetadata = 
@@ -558,6 +564,8 @@ public class Metadata {
             new PropertyName("alternativeColumnFillVisible");
     private final PropertyName alternativeRowFillVisibleName = 
             new PropertyName("alternativeRowFillVisible");
+    private final PropertyName alwaysOnTopName =
+            new PropertyName("alwaysOnTop");
     private final PropertyName anchorLocationName = 
             new PropertyName("anchorLocation");
     private final PropertyName anchorXName = 
@@ -760,6 +768,10 @@ public class Metadata {
             new PropertyName("fontSmoothingType");
     private final PropertyName forceZeroInRangeName = 
             new PropertyName("forceZeroInRange");
+    private final PropertyName fullScreenName =
+            new PropertyName("fullScreen");
+    private final PropertyName fullScreenExitHintName =
+            new PropertyName("fullScreenExitHint");
     private final PropertyName gapStartAndEndName = 
             new PropertyName("gapStartAndEnd");
     private final PropertyName graphicName = 
@@ -798,6 +810,8 @@ public class Metadata {
             new PropertyName("htmlText");
     private final PropertyName hvalueName = 
             new PropertyName("hvalue");
+    private final PropertyName iconifiedName =
+            new PropertyName("iconified");
     private final PropertyName idName = 
             new PropertyName("id");
     private final PropertyName imageName = 
@@ -854,6 +868,8 @@ public class Metadata {
             new PropertyName("maxPageIndicatorCount");
     private final PropertyName maxWidthName = 
             new PropertyName("maxWidth");
+    private final PropertyName maximizedName =
+            new PropertyName("maximized");
     private final PropertyName menusName = 
             new PropertyName("menus");
     private final PropertyName meshName = 
@@ -1084,6 +1100,8 @@ public class Metadata {
             new PropertyName("scaleY");
     private final PropertyName scaleZName = 
             new PropertyName("scaleZ");
+    private final PropertyName sceneName =
+            new PropertyName("scene");
     private final PropertyName scopeName = 
             new PropertyName("scope");
     private final PropertyName scrollLeftName = 
@@ -1638,6 +1656,12 @@ public class Metadata {
                 true, /* readWrite */
                 true, /* defaultValue */
                 new InspectorPath("Properties", "Specific", 94));
+    private final ValuePropertyMetadata alwaysOnTopPropertyMetadata =
+            new BooleanPropertyMetadata(
+                alwaysOnTopName,
+                true, /* readWrite */
+                false, /* defaultValue */
+                new InspectorPath("Layout", "Extras", 9));
     private final ValuePropertyMetadata anchorLocationPropertyMetadata =
             new EnumerationPropertyMetadata(
                 anchorLocationName,
@@ -2363,6 +2387,18 @@ public class Metadata {
                 true, /* readWrite */
                 true, /* defaultValue */
                 new InspectorPath("Properties", "Specific", 122));
+    private final ValuePropertyMetadata fullScreenPropertyMetadata =
+            new BooleanPropertyMetadata(
+                fullScreenName,
+                true, /* readWrite */
+                false, /* defaultValue */
+                new InspectorPath("Layout", "Extras", 10));
+    private final ValuePropertyMetadata fullScreenExitHintPropertyMetadata =
+            new StringPropertyMetadata(
+                fullScreenExitHintName,
+                true, /* readWrite */
+                "", /* defaultValue */
+                new InspectorPath("Layout", "Extras", 11));
     private final ValuePropertyMetadata gapStartAndEndPropertyMetadata =
             new BooleanPropertyMetadata(
                 gapStartAndEndName,
@@ -2511,6 +2547,12 @@ public class Metadata {
                 true, /* readWrite */
                 0.0, /* defaultValue */
                 new InspectorPath("Properties", "Specific", 106));
+    private final ValuePropertyMetadata iconifiedPropertyMetadata =
+            new BooleanPropertyMetadata(
+                iconifiedName,
+                true, /* readWrite */
+                false, /* defaultValue */
+                new InspectorPath("Layout", "Extras", 12));
     private final ValuePropertyMetadata idPropertyMetadata =
             new StringPropertyMetadata(
                 idName,
@@ -2730,6 +2772,12 @@ public class Metadata {
                 true, /* readWrite */
                 Double.MAX_VALUE, /* defaultValue */
                 new InspectorPath("Layout", "Size", 5));
+    private final ValuePropertyMetadata maximizedPropertyMetdata =
+            new BooleanPropertyMetadata(
+                maximizedName,
+                true, /* readWrite */
+                false, /* defaultValue */
+                new InspectorPath("Layout", "Extras", 13));
     private final ComponentPropertyMetadata menusPropertyMetadata =
             new ComponentPropertyMetadata(
                 menusName,
@@ -3543,6 +3591,11 @@ public class Metadata {
                 true, /* readWrite */
                 1.0, /* defaultValue */
                 new InspectorPath("Layout", "Transforms", 4));
+    private final ComponentPropertyMetadata scene_stage_PropertyMetadata =
+            new ComponentPropertyMetadata(
+                    sceneName,
+                    SceneMetadata,
+                    false);
     private final ComponentPropertyMetadata scopePropertyMetadata =
             new ComponentPropertyMetadata(
                 scopeName,
@@ -4901,6 +4954,7 @@ public class Metadata {
         componentClassMap.put(StackPaneMetadata.getKlass(), StackPaneMetadata);
         componentClassMap.put(StackedAreaChartMetadata.getKlass(), StackedAreaChartMetadata);
         componentClassMap.put(StackedBarChartMetadata.getKlass(), StackedBarChartMetadata);
+        componentClassMap.put(StageMetadata.getKlass(), StageMetadata);
         componentClassMap.put(SubSceneMetadata.getKlass(), SubSceneMetadata);
         componentClassMap.put(SwingNodeMetadata.getKlass(), SwingNodeMetadata);
         componentClassMap.put(TabMetadata.getKlass(), TabMetadata);
@@ -4927,6 +4981,7 @@ public class Metadata {
         componentClassMap.put(VLineToMetadata.getKlass(), VLineToMetadata);
         componentClassMap.put(ValueAxisMetadata.getKlass(), ValueAxisMetadata);
         componentClassMap.put(WebViewMetadata.getKlass(), WebViewMetadata);
+        componentClassMap.put(WindowMetadata.getKlass(), WindowMetadata);
         componentClassMap.put(XYChartMetadata.getKlass(), XYChartMetadata);
         componentClassMap.put(IncludeElementMetadata.getKlass(), IncludeElementMetadata);
 
@@ -5760,6 +5815,19 @@ public class Metadata {
         StackedBarChartMetadata.getProperties().add(categoryGapPropertyMetadata);
         StackedBarChartMetadata.getProperties().add(styleClass_c12_PropertyMetadata);
 
+        StageMetadata.getProperties().add(alwaysOnTopPropertyMetadata);
+        StageMetadata.getProperties().add(scene_stage_PropertyMetadata);
+        StageMetadata.getProperties().add(fullScreenPropertyMetadata);
+        StageMetadata.getProperties().add(fullScreenExitHintPropertyMetadata);
+        StageMetadata.getProperties().add(iconifiedPropertyMetadata);
+        StageMetadata.getProperties().add(maxHeight_MAX_PropertyMetadata);
+        StageMetadata.getProperties().add(maximizedPropertyMetdata);
+        StageMetadata.getProperties().add(maxWidth_MAX_PropertyMetadata);
+        StageMetadata.getProperties().add(minHeight_0_PropertyMetadata);
+        StageMetadata.getProperties().add(minWidth_0_PropertyMetadata);
+        StageMetadata.getProperties().add(resizable_Boolean_PropertyMetadata);
+        StageMetadata.getProperties().add(titlePropertyMetadata);
+
         SubSceneMetadata.getProperties().add(accessibleRole_NODE_PropertyMetadata);
         SubSceneMetadata.getProperties().add(fill_NULL_PropertyMetadata);
         SubSceneMetadata.getProperties().add(height_Double_0_PropertyMetadata);
@@ -6011,6 +6079,13 @@ public class Metadata {
         WebViewMetadata.getProperties().add(styleClass_c48_PropertyMetadata);
         WebViewMetadata.getProperties().add(width_Double_ro_PropertyMetadata);
         WebViewMetadata.getProperties().add(zoomPropertyMetadata);
+
+        WindowMetadata.getProperties().add(onCloseRequestPropertyMetadata);
+        WindowMetadata.getProperties().add(onHiddenPropertyMetadata);
+        WindowMetadata.getProperties().add(onHidingPropertyMetadata);
+        WindowMetadata.getProperties().add(onShowingPropertyMetadata);
+        WindowMetadata.getProperties().add(onShownPropertyMetadata);
+        WindowMetadata.getProperties().add(opacityPropertyMetadata);
 
         XYChartMetadata.getProperties().add(alternativeColumnFillVisiblePropertyMetadata);
         XYChartMetadata.getProperties().add(alternativeRowFillVisiblePropertyMetadata);

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
@@ -84,6 +84,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
+import javafx.stage.Stage;
 
 /**
  *
@@ -102,6 +103,7 @@ public class DesignHierarchyMask {
         // TODO(elp) : verify that it is complete 
         CONTENT,
         ROOT,
+        SCENE,
         TOP,
         BOTTOM,
         LEFT,
@@ -136,6 +138,7 @@ public class DesignHierarchyMask {
     private static final PropertyName graphicName = new PropertyName("graphic");
     private static final PropertyName contentName = new PropertyName("content");
     private static final PropertyName rootName = new PropertyName("root");
+    private static final PropertyName sceneName = new PropertyName("scene");
     private static final PropertyName expandableContentName = new PropertyName("expandableContent");
     private static final PropertyName headerName = new PropertyName("header");
     private static final PropertyName topName = new PropertyName("top");
@@ -388,7 +391,8 @@ public class DesignHierarchyMask {
                 || sceneGraphObject instanceof TextInputControl
                 || sceneGraphObject instanceof TitledPane
                 || sceneGraphObject instanceof Tooltip
-                || sceneGraphObject instanceof TreeTableColumn;
+                || sceneGraphObject instanceof TreeTableColumn
+                || sceneGraphObject instanceof Stage;
     }
     
     public boolean isResourceKey() {
@@ -488,6 +492,9 @@ public class DesignHierarchyMask {
             case CONTENT:
             case ROOT:
                 result = javafx.scene.Node.class;
+                break;
+            case SCENE:
+                result = javafx.scene.Scene.class;
                 break;
             case XAXIS:
             case YAXIS:
@@ -682,6 +689,8 @@ public class DesignHierarchyMask {
                 || sceneGraphObject instanceof Tooltip
                 || sceneGraphObject instanceof TreeTableColumn) {
             propertyName = new PropertyName("text");
+        } else if (sceneGraphObject instanceof Stage) {
+            propertyName = new PropertyName("title");
         }
         return propertyName;
     }
@@ -701,6 +710,9 @@ public class DesignHierarchyMask {
                 break;
             case ROOT:
                 result = rootName;
+                break;
+            case SCENE:
+                result = sceneName;
                 break;
             case EXPANDABLE_CONTENT:
                 result = expandableContentName;
@@ -1062,6 +1074,7 @@ public class DesignHierarchyMask {
         return (this.isAcceptingSubComponent()
                 || this.isAcceptingAccessory(Accessory.CONTENT)
                 || this.isAcceptingAccessory(Accessory.ROOT)
+                || this.isAcceptingAccessory(Accessory.SCENE)
                 || this.isAcceptingAccessory(Accessory.CENTER)
                 || this.isAcceptingAccessory(Accessory.TOP)
                 || this.isAcceptingAccessory(Accessory.RIGHT)

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/metadata/util/DesignHierarchyMask.java
@@ -101,6 +101,7 @@ public class DesignHierarchyMask {
         // Single-valued sub-components treated as accessories
         // TODO(elp) : verify that it is complete 
         CONTENT,
+        ROOT,
         TOP,
         BOTTOM,
         LEFT,
@@ -134,6 +135,7 @@ public class DesignHierarchyMask {
     }
     private static final PropertyName graphicName = new PropertyName("graphic");
     private static final PropertyName contentName = new PropertyName("content");
+    private static final PropertyName rootName = new PropertyName("root");
     private static final PropertyName expandableContentName = new PropertyName("expandableContent");
     private static final PropertyName headerName = new PropertyName("header");
     private static final PropertyName topName = new PropertyName("top");
@@ -484,6 +486,7 @@ public class DesignHierarchyMask {
             case PLACEHOLDER:
             case CLIP:
             case CONTENT:
+            case ROOT:
                 result = javafx.scene.Node.class;
                 break;
             case XAXIS:
@@ -695,6 +698,9 @@ public class DesignHierarchyMask {
             case DP_CONTENT:
             case EX_CONTENT:
                 result = contentName;
+                break;
+            case ROOT:
+                result = rootName;
                 break;
             case EXPANDABLE_CONTENT:
                 result = expandableContentName;
@@ -1055,6 +1061,7 @@ public class DesignHierarchyMask {
     public boolean needResizeWhenTopElement() {
         return (this.isAcceptingSubComponent()
                 || this.isAcceptingAccessory(Accessory.CONTENT)
+                || this.isAcceptingAccessory(Accessory.ROOT)
                 || this.isAcceptingAccessory(Accessory.CENTER)
                 || this.isAcceptingAccessory(Accessory.TOP)
                 || this.isAcceptingAccessory(Accessory.RIGHT)

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
@@ -70,7 +70,6 @@ import javafx.scene.transform.Scale;
 import javafx.scene.transform.Translate;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.stage.WindowEvent;
 
 /**
@@ -287,7 +286,7 @@ public final class PreviewWindowController extends AbstractWindowController {
                         throw new RuntimeException("Bug in PreviewWindowController::requestUpdate", ex); //NOI18N
                     }
 
-                    Object sceneGraphRoot = clone.getSceneGraphRoot();
+                    Object sceneGraphRoot = clone.getDisplayNodeOrSceneGraphRoot();
                     themeStyleSheetString = editorControllerTheme.getStylesheetURL();
 
                     if (sceneGraphRoot instanceof Parent) {

--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/preview/PreviewWindowController.java
@@ -297,7 +297,7 @@ public final class PreviewWindowController extends AbstractWindowController {
 
                         // Compute the proper styling
                         List<String> newStyleSheets1 = new ArrayList<>();
-                        computeStyleSheets(newStyleSheets1, sceneGraphRoot);
+                        computeStyleSheets(newStyleSheets1, sceneGraphRoot, clone.getDisplayStylesheets());
 
                         // Clean all styling
                         ((Parent) sceneGraphRoot).getStylesheets().removeAll();
@@ -310,7 +310,7 @@ public final class PreviewWindowController extends AbstractWindowController {
 
                         // Compute the proper styling
                         List<String> newStyleSheets2 = new ArrayList<>();
-                        computeStyleSheets(newStyleSheets2, sceneGraphRoot);
+                        computeStyleSheets(newStyleSheets2, sceneGraphRoot, clone.getDisplayStylesheets());
 
                         // Apply the new styling as a whole
                         sp1.getStylesheets().addAll(newStyleSheets2);
@@ -599,7 +599,7 @@ public final class PreviewWindowController extends AbstractWindowController {
         requestUpdate(IMMEDIATE);
     }
 
-    private void computeStyleSheets(List<String> newStyleSheets, Object sceneGraphRoot) {
+    private void computeStyleSheets(List<String> newStyleSheets, Object sceneGraphRoot, List<String> displayStylesheets) {
         if (sceneGraphRoot instanceof Parent) {
             // At that stage current style sheets are the one defined within the FXML
             ObservableList<String> currentStyleSheets = ((Parent) sceneGraphRoot).getStylesheets();
@@ -608,6 +608,8 @@ public final class PreviewWindowController extends AbstractWindowController {
                 newStyleSheets.add(stylesheet);
             }
         }
+
+        newStyleSheets.addAll(displayStylesheets);
 
         // Add style sheet set thanks Preview > Scene Style Sheets > Add a Style Sheet
         if (sceneStyleSheet != null) {

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/library/builtin/Scene.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/library/builtin/Scene.fxml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2018, Gluon and/or its affiliates.
+  All rights reserved. Use is subject to license terms.
+
+  This file is available and licensed under the following license:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the distribution.
+  - Neither the name of Oracle Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<?import javafx.scene.Scene?>
+<?import javafx.scene.layout.AnchorPane?>
+
+<Scene>
+    <AnchorPane prefWidth="200" prefHeight="200" />
+</Scene>

--- a/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/library/builtin/Stage.fxml
+++ b/kit/src/main/resources/com/oracle/javafx/scenebuilder/kit/library/builtin/Stage.fxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2018, Gluon and/or its affiliates.
+  All rights reserved. Use is subject to license terms.
+
+  This file is available and licensed under the following license:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the distribution.
+  - Neither the name of Oracle Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<?import javafx.scene.Scene?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.stage.Stage?>
+
+<Stage>
+    <scene>
+        <Scene>
+            <AnchorPane prefWidth="200" prefHeight="200" />
+        </Scene>
+    </scene>
+</Stage>


### PR DESCRIPTION
While the main aim of this PR is to support `javafx.scene.Scene` and `javafx.stage.Stage`, the solution implemented can be easily extended to other non-Node FXML roots, e.g. (`Tab`, `Dialog`)

As an example, a preliminary solution for  https://bitbucket.org/gluon-oss/scenebuilder/issues/134/tab-not-accepted-as-root-element-in-fxml is included as well.

Todo:
* [x] Support stylesheets on Scene node
* [x] ~Stylesheet application order may be slightly botched (Should be Theme, then FXML file stylesheets, then the Stylesheets added with Preview -> Scene Style Sheets)~ (Turns out this is an existing bug in scene builder, the order of stylesheets in the editor and preview window are different)
* [x] Finish filling in all properties of `Window`  in `Metadata`
* [x] Finish filling in all properties of `Stage` in `Metadata`
  * [x] alwaysOnTop (default: false)
  * [x] fullSceenExitHint (default: null) (note: editor does not support null)
  * [x] ~fullScreenExitKey (default: null)~ (lol getter name does not match, javafx pls)
  * [x] fullScreen (default: false)
  * [x] iconified (default: false)
  * [x] maximized (default: false)
* [x] Finish filling in all properties of `Scene` in `Metadata`.
  * [x] ~camera~ (will not support)
  * [x] ~cursor~ (cursor does not exist or is readonly)
  * [x] fill
  * [x] ~nodeOrientation~ (nodeOrientation does not exist or is readonly)
  * [x] ~userAgentStylesheet~ (property userAgentStylesheet does not exist or is readonly)
* [x] makeTring, makePring etc. can't return `null`. Fix `SceneDriver`, `StageDriver` to do the correct thing in these cases. (Manifests as silent NPEs when e.g. doing a drag-selection)
* [x] intersectsBounds
* [x] Fix metadata numbers

Relevant resources:
* https://bitbucket.org/gluon-oss/scenebuilder/issues/134/tab-not-accepted-as-root-element-in-fxml (Upstream issue)
    > It would be nice if SceneBuilder were to support display and proper editing of FXML files with non-Node and non-Parent UI objects as root : Window, Dialog, Tab, ...
* [JavaFX Using alternative FXML structure for Title (Stage is root)](https://stackoverflow.com/questions/25510606/javafx-using-alternative-fxml-structure-for-title-stage-is-root)
    > Also, you could create a feature request against SceneBuilder (it is called the "design tool" in the issue tracker), to request direct support for FXML files with stage roots and scenes included in the FXML. 
